### PR TITLE
Updated

### DIFF
--- a/MMLayershots/CALayer+MMLayershots.m
+++ b/MMLayershots/CALayer+MMLayershots.m
@@ -20,9 +20,8 @@ static char kAssociatedObjectHiddenState;
     objc_setAssociatedObject(self, &kAssociatedObjectHiddenState, [NSNumber numberWithBool:self.hidden], OBJC_ASSOCIATION_RETAIN);
     self.hidden = YES;
     
-    if (self.sublayers.count>0) {
-        [self.sublayers makeObjectsPerformSelector:@selector(beginHidingSublayers)];
-    }
+  for (CALayer *layer in [[rootLayer.sublayers copy] autorelease]) {
+    [layer removeFromSuperlayer];
 }
 
 - (void)endHidingSublayers {


### PR DESCRIPTION
Indiscriminately removing all sublayers causes nasty crashes in iOS 7, which can occur much later in the program's execution. I have tested this thoroughly using both rootLayer.sublayers = nil and [rootLayer.sublayers makeObjectsPerformSelector:@selector(removeFromSuperlayer)]...
