### PR TITLE
Added folder generation / Layer names

### DIFF
--- a/MMLayershots/MMLayershots.m
+++ b/MMLayershots/MMLayershots.m
@@ -183,7 +183,7 @@ static MMLayershots *_sharedInstance;
 
     for (UIWindow *window in allWindows) {
         [window.layer beginHidingSublayers];
-        [psdWriter addImagesForLayer:window.layer renderedToRootLayer:window.layer];
+        [psdWriter addImagesForView:window renderedToRootView:window];
         [window.layer endHidingSublayers];
     }
     NSData *psdData = [psdWriter createPSDData];

--- a/MMLayershots/SFPSDWriter+MMLayershots.h
+++ b/MMLayershots/SFPSDWriter+MMLayershots.h
@@ -10,6 +10,6 @@
 
 @interface SFPSDWriter (MMLayershots)
 
-- (void)addImagesForLayer:(CALayer *)layer renderedToRootLayer:(CALayer *)rootLayer;
+- (void)addImagesForView:(UIView *)view renderedToRootView:(UIView *)rootView;
 
 @end

--- a/MMLayershots/SFPSDWriter+MMLayershots.m
+++ b/MMLayershots/SFPSDWriter+MMLayershots.m
@@ -12,7 +12,149 @@
 
 // Currently all layers are named "Layer".
 // See https://github.com/vpdn/MMLayershots/issues/2 for improvement suggestions.
+- (void)addImagesForView:(UIView *)view renderedToRootView:(UIView *)rootView
+{
+    if (view.layer.hiddenBeforeHidingSublayers==NO) {
+        view.layer.hidden = NO;
+        if (view.layer.sublayers.count>0) {
+            // add self
+            UIImage *image = [rootView.layer imageRepresentation];
 
+            // Prevent from adding empty images
+            CGImageRef cgImage = image.CGImage;
+            if (![self isImageEmpty:cgImage])
+            {
+                // Compute layer name
+                NSString *layerName = [self computeNameForView:view];
+                
+                // Add computed image
+                [self addLayerWithCGImage:cgImage andName:layerName andOpacity:1.0 andOffset:CGPointZero];
+                
+                // hide own layer visuals while rendering children
+                NSMutableDictionary *layerProperties = [NSMutableDictionary new];
+                
+                if (view.layer.backgroundColor) {
+                    layerProperties[@"backgroundColor"] = (__bridge id)(view.layer.backgroundColor);
+                    view.layer.backgroundColor = nil;
+                }
+                if (view.layer.borderColor) {
+                    layerProperties[@"borderColor"] = (__bridge id)(view.layer.borderColor);
+                    view.layer.borderColor = nil;
+                }
+                if (view.layer.shadowColor) {
+                    layerProperties[@"shadowColor"] = (__bridge id)(view.layer.shadowColor);
+                    view.layer.shadowColor = nil;
+                }
+                
+                NSString *groupName = nil;
+                if ([view isKindOfClass:[UIScrollView class]]               ||
+                    [view isKindOfClass:[UITableViewCell class]]            ||
+                    [view isKindOfClass:[UICollectionViewCell class]]       ||
+                    [view isKindOfClass:[UICollectionReusableView class]]   ||
+                    [view isKindOfClass:[UITableViewHeaderFooterView class]])
+                {
+                    // Compute group name
+                    groupName = [[view class] description];
+                    
+                    // create layer group
+                    [self openGroupLayerWithName:groupName];
+                }
+                
+                // render children
+                [[view.subviews copy] enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+                    [self addImagesForView:obj renderedToRootView:rootView];
+                }];
+                
+                // reset layer colors
+                for (NSString *layerProperty in layerProperties) {
+                    [view.layer setValue:layerProperties[layerProperty] forKey:layerProperty];
+                }
+                
+                // close layer group
+                if (groupName)
+                {
+                    NSError *error = nil;
+                    [self closeCurrentGroupLayerWithError:&error];
+                    if (error)
+                        NSLog(@"%@ - %@", error.localizedDescription, error.localizedRecoveryOptions);
+                }
+            }
+        }
+        else
+        {
+            // Prevent from adding empty images
+            CGImageRef cgImage = [rootView.layer imageRepresentation].CGImage;
+            if (![self isImageEmpty:cgImage])
+            {
+                // base case
+                NSString *layerName = [self computeNameForView:view];
+                [self addLayerWithCGImage:cgImage
+                                  andName:layerName
+                               andOpacity:1.0
+                                andOffset:CGPointZero];
+            }
+        }
+
+        view.layer.hidden = YES;
+    }
+}
+
+- (NSString *)computeNameForView:(UIView *)aView
+{
+    NSString *viewName = aView.accessibilityLabel;
+    if (viewName)
+        return viewName;
+
+    // Check for text attribute (UILabel / UITextView)
+    if ([aView respondsToSelector:@selector(text)])
+    {
+        id viewText = [aView performSelector:@selector(text)];
+        if ([viewText isKindOfClass:[NSString class]])
+        {
+            if ([(NSString *)viewText length])
+                return viewText;
+        }
+    }
+
+    // Check for attributedText (UILabel / UITextView / UITextField)
+    if ([aView respondsToSelector:@selector(attributedText)])
+    {
+        id viewText = [aView performSelector:@selector(attributedText)];
+        if ([viewText isKindOfClass:[NSAttributedString class]])
+        {
+            if ([(NSAttributedString *)viewText length])
+                return [(NSAttributedString *)viewText string];
+        }
+    }
+
+    // Check for UIButton
+    if ([aView isKindOfClass:[UIButton class]])
+    {
+        // Normal title
+        NSString *viewText = [(UIButton *)aView currentTitle];
+        if (viewText.length > 0)
+            return viewText;
+        
+        // Attributed title
+        viewText = [[(UIButton *)aView currentAttributedTitle] string];
+        if (viewText.length > 0)
+            return viewText;
+    }
+
+    // No text found, Add more tests ?
+    return [[aView class] description];
+}
+
+#pragma mark - Utils
+- (BOOL)isImageEmpty:(CGImageRef)anImage
+{
+    // TODO Add test to check is imageRef content is all transparent ?
+    return NO;
+}
+
+
+// Old implementation for reference. Now browing throught View instead of layers.
+/*
 - (void)addImagesForLayer:(CALayer *)layer renderedToRootLayer:(CALayer *)rootLayer {
     if (layer.hiddenBeforeHidingSublayers==NO) {
         layer.hidden = NO;
@@ -63,5 +205,5 @@
         layer.hidden = YES;
     }
 }
-
+*/
 @end

--- a/MMLayershotsDemo/LayershotsDemo/MMViewController.m
+++ b/MMLayershotsDemo/LayershotsDemo/MMViewController.m
@@ -25,6 +25,9 @@
 - (void)setupSampleView {
     self.view.backgroundColor = [UIColor lightGrayColor];
     
+    UIScrollView *scrollView = [[UIScrollView alloc] initWithFrame:self.view.bounds];
+    [self.view addSubview:scrollView];
+    
     // white box
     UIView *box = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)];
     box.backgroundColor = [UIColor whiteColor];
@@ -37,7 +40,7 @@
     box.layer.shadowOffset = CGSizeMake(2.0, 2.0);
     box.layer.shadowRadius = 2.0;
     box.layer.shadowOpacity = 0.5;
-    [self.view addSubview:box];
+    [scrollView addSubview:box];
 
     // orange box in box
     UIView *box2 = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 30, 30)];


### PR DESCRIPTION
Implementation proposition.
- Refactored code to use UIView instead of CALayer
  -> Allows use to retrieve View class, and useful properties
- Added layer grouping
  -> Group is rootview is a container view
  -> UIScrollView (So UITableView and UICollectionView will also work)
  -> Cells (UICollectionViewCell / UITableViewCell)
  -> Header / Footer / ReusableView
- Added layers naming
  -> First check accessibilityLabel
  -> Next, check for text + attributedText property
         -> UILabel, UITextView, UITextField
         -> May be updated, perhaps, to add directly a Text layer in next versions, no ?
  -> Also check for buttons (title / attributedTitle)
  -> Finally, use UIView class name as placeholder
- Added isImageEmpty method
  -> return NO for now, but it may be useful to write a method that will trim empty layers from PSD, no ?
- Updated sample to add a ScrollView, for text purpose
  -> In my opinion, we should create a more complex example, with tableview, etc...
- Old implementation commented, for futur reference
  Regards,
