### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The run the following command to initialize the submodule:
 
 ##How to use Layershots?
 
-The preferred way to install is via Cocoapods. Add this to your Podfile:
+The preferred way to install is via CocoaPods. Add this to your Podfile:
 	
 	pod 'MMLayershots'
 
@@ -115,4 +115,4 @@ For a list of outstanding / missing features, check out the github issues page. 
 [framer.js sample]: http://vpdn.github.io/images/2014-05-18_Layershots/clockshots_animation.gif
 [Framer.js]: http://framerjs.com
 [Clockshots]: http://clockshots.com
-[Cocoapods Trunk]: http://blog.cocoapods.org/CocoaPods-Trunk/#trunk
+[CocoaPods Trunk]: http://blog.cocoapods.org/CocoaPods-Trunk/#trunk


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
